### PR TITLE
New call to use_ok messes up Test::CPAN::Changes plan

### DIFF
--- a/lib/Dist/Zilla/Plugin/Test/CPAN/Changes.pm
+++ b/lib/Dist/Zilla/Plugin/Test/CPAN/Changes.pm
@@ -92,7 +92,9 @@ __DATA__
 __[ xt/release/cpan-changes.t ]__
 #!perl
 
-use Test::More;
+use Test::More tests => 2;
 use_ok('Test::CPAN::Changes');
-changes_ok();
+subtest 'changes_ok' => sub {
+    changes_ok();
+};
 done_testing();


### PR DESCRIPTION
I noticed the new version of the plugin calls `use_ok()`, which caused my module to do the following. The attached patch fixes this issue by running `changes_ok()` as a subtest.

```
$ RELEASE_TESTING=1 prove --lib t/release-cpan-changes.t
t/release-cpan-changes.t .. 1/?
#   Failed test 'planned to run 4 but done_testing() expects 5'
#   at /home/mgardner/perl5/perlbrew/perls/perl-5.16.3/lib/5.16.3/Test/More.pm line 221.
# Looks like you planned 4 tests but ran 6.
# Looks like you failed 1 test of 6 run.
t/release-cpan-changes.t .. Dubious, test returned 1 (wstat 256, 0x100)
All 4 subtests passed

Test Summary Report
-------------------
t/release-cpan-changes.t (Wstat: 256 Tests: 6 Failed: 2)
  Failed tests:  5-6
  Non-zero exit status: 1
  Parse errors: Plan (1..4) must be at the beginning or end of the TAP output
                Bad plan.  You planned 4 tests but ran 6.
Files=1, Tests=6,  0 wallclock secs ( 0.03 usr  0.00 sys +  0.02 cusr  0.00 csys =  0.05 CPU)
Result: FAIL
```
