### PR TITLE
Eliminate Moose::Autobox in tests.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl module {{$dist->name}}
 
 {{$NEXT}}
+    * Eliminate use of Moose::Autobox in tests [kentnl; GH#5]
 
 0.008     2013-04-17
     * eliminate the FileMunger stage by modifying the file as it is created

--- a/t/01-changes.t
+++ b/t/01-changes.t
@@ -4,7 +4,6 @@ use Test::More 0.94 tests => 2;
 use Test::CPAN::Changes;
 use autodie;
 use Test::DZil;
-use Moose::Autobox;
 
 my $changes = do { local $/; <DATA>};
 
@@ -28,10 +27,10 @@ subtest 'Changes' => sub {
 
     my $has_changelog = grep(
         $_->name eq $changelog,
-        $tzil->files->flatten
+        @{ $tzil->files }
     );
     ok($has_changelog, 'changelog exists')
-        or diag explain $tzil->files->flatten;
+        or diag explain @{ $tzil->files };
 
     my $changes_test = $tzil->slurp_file('build/xt/release/cpan-changes.t');
     like($changes_test, qr{\Qchanges_file_ok('Changes');\E}, 'We have a cpan-changes test');
@@ -57,10 +56,10 @@ subtest 'CHANGES' => sub {
 
     my $has_changelog = grep(
         $_->name eq $changelog,
-        $tzil->files->flatten
+        @{ $tzil->files }
     );
     ok($has_changelog, 'changelog exists')
-        or diag explain $tzil->files->flatten;
+        or diag explain @{ $tzil->files };
 
     my $changes_test = $tzil->slurp_file('build/xt/release/cpan-changes.t');
     like($changes_test, qr{\Qchanges_file_ok('$changelog');\E}, 'We have a cpan-changes test');


### PR DESCRIPTION
This eliminates an unnecessarily fragile path that currently impedes dzil
work on bleadperls.

Note: Testing only done with `prove` as I was unable to build this dist even on an older devperl with autobox working ( Devel::Cover, Template::Toolkit, Test::LeakTrace all break in your bundles installpath )