### PR TITLE
Prefer `use` over `use_ok`

### DIFF
--- a/lib/Dist/Zilla/Plugin/Test/CPAN/Changes.pm
+++ b/lib/Dist/Zilla/Plugin/Test/CPAN/Changes.pm
@@ -102,8 +102,8 @@ __[ xt/release/cpan-changes.t ]__
 use strict;
 use warnings;
 
-use Test::More 0.96 tests => 2;
-use_ok('Test::CPAN::Changes');
+use Test::More 0.96 tests => 1;
+use Test::CPAN::Changes;
 subtest 'changes_ok' => sub {
     changes_file_ok('CHANGESFILENAME');
 };


### PR DESCRIPTION
In case you agree with #8 then this should be enough to fix it. If not feel free to ignore this pull request. This is part of the [CPAN Pull Request Challenge](http://cpan-prc.org/).