### PR TITLE
argh fix stupid typo

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl module {{$dist->name}}
 
 {{$NEXT}}
+  - fix silly typo in method name [ether's fault, gh-11]
 
 0.011     2016-06-11
   - Comments explaining where the added test came from [ether, gh-10]

--- a/lib/Dist/Zilla/Plugin/Test/CPAN/Changes.pm
+++ b/lib/Dist/Zilla/Plugin/Test/CPAN/Changes.pm
@@ -46,7 +46,6 @@ and that file will be tested instead.
 has changelog => (
     is      => 'ro',
     isa     => 'Str',
-    predicate => 'has_changelog',
     default => 'Changes',
 );
 
@@ -56,7 +55,7 @@ around dump_config => sub
     my $config = $self->$orig;
 
     $config->{+__PACKAGE__} = {
-        $self->has_changelog ? ( changelog => $self->Changes ) : (),
+        changelog => $self->changelog,
         blessed($self) ne __PACKAGE__
             ? ( version => (defined __PACKAGE__->VERSION ? __PACKAGE__->VERSION : 'dev') )
             : (),


### PR DESCRIPTION
and since this is a non-lazy attribute that doesn't permit undef values, the
predicate will always return true, so we might as well delete it entirely.

(I'm so sorry!)
